### PR TITLE
Add @pytest.mark.nondestructive markers

### DIFF
--- a/tests/test_stub_attribution_campaign.py
+++ b/tests/test_stub_attribution_campaign.py
@@ -59,6 +59,7 @@ def assert_good(new_dict, source, medium, campaign, term):
     assert new_dict == old_dict
 
 
+@pytest.mark.nondestructive
 @pytest.mark.parametrize('source, medium, campaign, term', [
     ('google', 'paidsearch', 'Fake%20campaign', 'test term')])
 def test_campaign_flow_param_values(base_url, selenium, source, medium, campaign, term):

--- a/tests/test_stub_attribution_organic.py
+++ b/tests/test_stub_attribution_organic.py
@@ -54,6 +54,7 @@ def assert_good(new_dict, source, medium, campaign, content):
     assert new_dict == old_dict
 
 
+@pytest.mark.nondestructive
 @pytest.mark.parametrize('source, medium, campaign, content', [
     ('www.allizom.org', 'referral', '(not set)', '(not set)')])
 def test_organic_flow_param_values(base_url, selenium, source, medium, campaign, content):

--- a/tests/test_stub_attribution_organic.py
+++ b/tests/test_stub_attribution_organic.py
@@ -53,10 +53,11 @@ def test_organic_flow_param_values(base_url, selenium):
     # 1. compare the values we expect from breaking out downloadLink in derive_url()
     # 2. ...to the utm_param_values we expect to see for source, medium, campaign, and content
     derived_url = derive_url(selenium, '{0}/en-US/'.format(base_url))
-    source = urlparse.urlparse(base_url).hostname
-    medium = 'referral'
-    campaign = '(not set)'
-    content = '(not set)'
+    expected = {
+        'source': urlparse.urlparse(base_url).hostname,
+        'medium': 'referral',
+        'campaign': '(not set)',
+        'content': '(not set)'}
     actual = breakout_utm_param_values(derived_url)
 
-    assert actual == {'source': source, 'medium': medium, 'campaign': campaign, 'content': content}
+    assert actual == expected

--- a/tests/test_stub_attribution_organic.py
+++ b/tests/test_stub_attribution_organic.py
@@ -55,12 +55,13 @@ def assert_good(new_dict, source, medium, campaign, content):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('source, medium, campaign, content', [
-    ('www.allizom.org', 'referral', '(not set)', '(not set)')])
-def test_organic_flow_param_values(base_url, selenium, source, medium, campaign, content):
+@pytest.mark.parametrize('medium, campaign, content', [
+    ('referral', '(not set)', '(not set)')])
+def test_organic_flow_param_values(base_url, selenium, medium, campaign, content):
     # we:
     # 1. compare the values we expect from breaking out downloadLink in derive_url()
     # 2. ...to the utm_param_values we expect to see for source, medium, campaign, and content
     derived_url = derive_url(selenium, '{0}/en-US/'.format(base_url))
     new_dict = breakout_utm_param_values(derived_url)
+    source = urlparse.urlparse(base_url).hostname
     assert_good(new_dict, source, medium, campaign, content)

--- a/tests/test_stub_attribution_organic.py
+++ b/tests/test_stub_attribution_organic.py
@@ -47,21 +47,16 @@ def breakout_utm_param_values(generated_url):
     return equal_pieces_as_dict
 
 
-def assert_good(new_dict, source, medium, campaign, content):
-    old_dict = {'source': source, 'medium': medium, 'campaign': campaign, 'content': content}
-    print old_dict
-    print new_dict
-    assert new_dict == old_dict
-
-
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('medium, campaign, content', [
-    ('referral', '(not set)', '(not set)')])
-def test_organic_flow_param_values(base_url, selenium, medium, campaign, content):
+def test_organic_flow_param_values(base_url, selenium):
     # we:
     # 1. compare the values we expect from breaking out downloadLink in derive_url()
     # 2. ...to the utm_param_values we expect to see for source, medium, campaign, and content
     derived_url = derive_url(selenium, '{0}/en-US/'.format(base_url))
-    new_dict = breakout_utm_param_values(derived_url)
     source = urlparse.urlparse(base_url).hostname
-    assert_good(new_dict, source, medium, campaign, content)
+    medium = 'referral'
+    campaign = '(not set)'
+    content = '(not set)'
+    actual = breakout_utm_param_values(derived_url)
+
+    assert actual == {'source': source, 'medium': medium, 'campaign': campaign, 'content': content}

--- a/tests/test_stub_attribution_search.py
+++ b/tests/test_stub_attribution_search.py
@@ -53,6 +53,7 @@ def assert_good(new_dict, source, medium, campaign, term):
     assert new_dict == old_dict
 
 
+@pytest.mark.nondestructive
 @pytest.mark.parametrize('source, medium, campaign, term', [
     ('google', 'paidsearch', 'Brand-US-GGL-Exact', 'download%20firefox')])
 def test_search_flow_param_values(base_url, selenium, source, medium, campaign, term):


### PR DESCRIPTION
@davehunt r?  and I could use help, if you'd be so kind, figuring out how to get the selenium object in so the base_url works in the test_organic case:

```
sdonner-17447:stubattribution-tests sdonner$ tox -e py27 -- --base-url https://www.mozilla.org
py27 installed: apipkg==1.4,appdirs==1.4.2,blessings==1.6,execnet==1.4.1,mozlog==3.4,packaging==16.8,py==1.4.32,pyparsing==2.1.10,pytest==3.0.6,pytest-base-url==1.3.0,pytest-html==1.14.1,pytest-metadata==1.2.0,pytest-selenium==1.9.0,pytest-variables==1.4,pytest-xdist==1.15.0,querystringsafe-base64==0.2.0,requests==2.13.0,selenium==3.0.2,six==1.10.0
py27 runtests: PYTHONHASHSEED='3960318429'
py27 runtests: commands[0] | pytest --driver=SauceLabs --capability browserName Chrome --capability platform Windows 10 --junit-xml=results/py27.xml --html=results/py27.html --log-raw=results/py27.log --base-url https://www.mozilla.org
================================================================== test session starts ===================================================================
platform darwin -- Python 2.7.10, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /Users/sdonner/stubattribution-tests/.tox/py27/bin/python2.7
cachedir: .cache
sensitiveurl: mozilla\.(com|org)
driver: SauceLabs
baseurl: https://www.mozilla.org
rootdir: /Users/sdonner/stubattribution-tests, inifile: tox.ini
plugins: xdist-1.15.0, variables-1.4, selenium-1.9.0, metadata-1.2.0, html-1.14.1, base-url-1.3.0, mozlog-3.4
[gw0] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw1] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw2] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw3] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw4] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw5] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw6] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw7] darwin Python 2.7.10 cwd: /Users/sdonner/stubattribution-tests
[gw0] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw1] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw2] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw3] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw4] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw5] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw6] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
[gw7] Python 2.7.10 (default, Feb  8 2017, 20:04:21)  -- [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
gw0 [3] / gw1 [3] / gw2 [3] / gw3 [3] / gw4 [3] / gw5 [3] / gw6 [3] / gw7 [3]
scheduling tests via LoadScheduling

tests/test_stub_attribution_search.py::test_search_flow_param_values[google-paidsearch-Brand-US-GGL-Exact-download%20firefox] 
tests/test_stub_attribution_campaign.py::test_campaign_flow_param_values[google-paidsearch-Fake%20campaign-test term] 
tests/test_stub_attribution_organic.py::test_organic_flow_param_values[{base_url}-referral-(not set)-(not set)] 
[gw1] PASSED tests/test_stub_attribution_campaign.py::test_campaign_flow_param_values[google-paidsearch-Fake%20campaign-test term] 
[gw6] PASSED tests/test_stub_attribution_search.py::test_search_flow_param_values[google-paidsearch-Brand-US-GGL-Exact-download%20firefox] 
[gw3] FAILED tests/test_stub_attribution_organic.py::test_organic_flow_param_values[{base_url}-referral-(not set)-(not set)] 

--------------------------------------- generated xml file: /Users/sdonner/stubattribution-tests/results/py27.xml ----------------------------------------
-------------------------------------- generated html file: /Users/sdonner/stubattribution-tests/results/py27.html ---------------------------------------
================================================================ short test summary info =================================================================
FAIL tests/test_stub_attribution_organic.py::test_organic_flow_param_values[{base_url}-referral-(not set)-(not set)]
======================================================================== FAILURES ========================================================================
________________________________________ test_organic_flow_param_values[{base_url}-referral-(not set)-(not set)] _________________________________________
[gw3] darwin -- Python 2.7.10 /Users/sdonner/stubattribution-tests/.tox/py27/bin/python2.7
base_url = 'https://www.mozilla.org'
selenium = <selenium.webdriver.remote.webdriver.WebDriver (session="27f07726c5e5401eb2560f37fdf727af")>
source = '{base_url}', medium = 'referral', campaign = '(not set)'
content = '(not set)'

    @pytest.mark.nondestructive
    @pytest.mark.parametrize('source, medium, campaign, content', [
        ('{base_url}', 'referral', '(not set)', '(not set)')])
    def test_organic_flow_param_values(base_url, selenium, source, medium, campaign, content):
        # we:
        # 1. compare the values we expect from breaking out downloadLink in derive_url()
        # 2. ...to the utm_param_values we expect to see for source, medium, campaign, and content
        derived_url = derive_url(selenium, '{0}/en-US/'.format(base_url))
        new_dict = breakout_utm_param_values(derived_url)
>       assert_good(new_dict, source, medium, campaign, content)

tests/test_stub_attribution_organic.py:66: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

new_dict = {'campaign': '(not set)', 'content': '(not set)', 'medium': 'referral', 'source': 'www.mozilla.org'}
source = '{base_url}', medium = 'referral', campaign = '(not set)'
content = '(not set)'

    def assert_good(new_dict, source, medium, campaign, content):
        old_dict = {'source': source, 'medium': medium, 'campaign': campaign, 'content': content}
        print old_dict
        print new_dict
>       assert new_dict == old_dict
E       assert {'campaign': ....mozilla.org'} == {'campaign': '... '{base_url}'}
E         Common items:
E         {'campaign': '(not set)', 'content': '(not set)', 'medium': 'referral'}
E         Differing items:
E         {'source': 'www.mozilla.org'} != {'source': '{base_url}'}
E         Full diff:
E         {'campaign': '(not set)',
E         'content': '(not set)',
E         'medium': 'referral',
E         -  'source': 'www.mozilla.org'}
E         +  'source': '{base_url}'}

tests/test_stub_attribution_organic.py:54: AssertionError
------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------
Stub Attribution download link is:
 https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US&attribution_code=c291cmNlPXd3dy5tb3ppbGxhLm9yZyZtZWRpdW09cmVmZXJyYWwmY2FtcGFpZ249KG5vdCBzZXQpJmNvbnRlbnQ9KG5vdCBzZXQpJnRpbWVzdGFtcD0xNDg4Mzk0MzA0&attribution_sig=ad23a27412330d06d8579d17a20667e6e8d7f3b29c64d83cb84faa189652350c
{'source': '{base_url}', 'medium': 'referral', 'content': '(not set)', 'campaign': '(not set)'}
{'source': 'www.mozilla.org', 'medium': 'referral', 'content': '(not set)', 'campaign': '(not set)'}
-------------------------------------------------------------------- pytest-selenium ---------------------------------------------------------------------
URL: https://www.mozilla.org/en-US/firefox/new/?scene=2
Sauce Labs Job: http://saucelabs.com/jobs/27f07726c5e5401eb2560f37fdf727af
========================================================== 1 failed, 2 passed in 11.51 seconds ===========================================================
ERROR: InvocationError: '/Users/sdonner/stubattribution-tests/.tox/py27/bin/pytest --driver=SauceLabs --capability browserName Chrome --capability platform Windows 10 --junit-xml=results/py27.xml --html=results/py27.html --log-raw=results/py27.log --base-url https://www.mozilla.org'
________________________________________________________________________ summary _________________________________________________________________________
ERROR:   py27: commands failed
```