### PR TITLE
Bump shared-library version to 1.9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def capabilities = [
 pipeline {
   agent any
   libraries {
-    lib('fxtest@1.6')
+    lib('fxtest@1.9')
   }
   options {
     ansiColor('xterm')


### PR DESCRIPTION
Ad-hoc job here: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/stubattribution.adhoc/11/console

Failure, pre-existing, is due to https://github.com/mozilla/stubattribution-tests/issues/53