### PR TITLE
Fix the path to and locator of the Download Firefox button

### DIFF
--- a/tests/test_stub_attribution_organic.py
+++ b/tests/test_stub_attribution_organic.py
@@ -11,13 +11,12 @@ import querystringsafe_base64
 def derive_url(selenium, generated_url):
     selenium.get(generated_url)
 
-    getFirefoxTodayLink = WebDriverWait(selenium, 10).until(
-        EC.element_to_be_clickable((By.ID, "fx-download-link")))
-    getFirefoxTodayLink.click()
-    downloadButton = WebDriverWait(selenium, 10).until(
-        EC.element_to_be_clickable((By.ID, "download-button-desktop-release")))
-    downloadButton.click()
-    downloadLink = selenium.find_element_by_id("direct-download-link").get_attribute("href")
+    firefoxHeaderNavLink = selenium.find_element_by_css_selector('li.item-firefox')
+    firefoxHeaderNavLink.click()
+    downloadFirefoxLink = WebDriverWait(selenium, 10).until(
+        EC.element_to_be_clickable((By.CSS_SELECTOR, '#download-intro .os_win a')))
+    downloadFirefoxLink.click()
+    downloadLink = selenium.find_element_by_id('direct-download-link').get_attribute('href')
     print "Stub Attribution download link is:\n %s" % downloadLink
 
     return downloadLink


### PR DESCRIPTION
@jrbenny35 r?

Flow:
1) loads mozilla.org (or baseURL)
2) clicks on "Firefox" at the top-left nav
3) clicks on the Download Firefox button
4) gets the resulting link and chops it up into its stub-attribution pieces, and compares

Dev: https://gist.github.com/stephendonner/fc5f5d82b6024f5578b2d83e9dab81e7
Staging: https://gist.github.com/stephendonner/eea0f33dc0c1af5b3c6a175b128479c2
Prod: https://gist.github.com/stephendonner/78f4a8a36251393daed126c523f0a436