### PR TITLE
Make firefoxHeaderNavLink use WebDriverWait

### DIFF
--- a/tests/test_stub_attribution_organic.py
+++ b/tests/test_stub_attribution_organic.py
@@ -11,7 +11,8 @@ import querystringsafe_base64
 def derive_url(selenium, generated_url):
     selenium.get(generated_url)
 
-    firefoxHeaderNavLink = selenium.find_element_by_css_selector('li.item-firefox')
+    firefoxHeaderNavLink = WebDriverWait(selenium, 10).until(
+        EC.element_to_be_clickable((By.CSS_SELECTOR, 'li.item-firefox')))
     firefoxHeaderNavLink.click()
     downloadFirefoxLink = WebDriverWait(selenium, 10).until(
         EC.element_to_be_clickable((By.CSS_SELECTOR, '#download-intro .os_win a')))


### PR DESCRIPTION
As promised (and I should've probably done in https://github.com/mozilla/stubattribution-tests/pull/56); @jrbenny35 r?