### PR TITLE
Add 5-minute interval SCM polling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
   }
   triggers {
     pollSCM('H/5 * * * *')
+    cron('@daily')
   }
   options {
     ansiColor('xterm')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     lib('fxtest@1.10')
   }
   triggers {
-    pollSCM('*/5 * * * *')
+    pollSCM('H/5 * * * *')
   }
   options {
     ansiColor('xterm')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,9 @@ pipeline {
   libraries {
     lib('fxtest@1.10')
   }
+  triggers {
+    pollSCM('*/5 * * * *')
+  }
   options {
     ansiColor('xterm')
     timestamps()


### PR DESCRIPTION
@davehunt thoughts?

I...haven't actually tested locally that this works, but I did read the docs: https://github.com/jenkinsci/pipeline-model-definition-plugin/wiki/Trigger-runs

About that aggressive 5-minute schedule: since we can't use downstream triggers from GitHub, I'd like to experiment, and closely watch, as we potentially make this (or similar) change across our repos.

The problem I'm trying to solve is: breaking change(s) land, and due to non-aggressive (or wrong!) crons, we don't know the build is broken until it's potentially (and usually is) a bit too late.

Finally, re: ```cron``` vs. ```pollSCM```, I read through https://issues.jenkins-ci.org/browse/JENKINS-40722?focusedCommentId=283250&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-283250 and have come to understand that (since we largely don't care about branches other than ```master```, ```pollSCM``` works fine for us.

And I know it's not worth *much*, but the ad-hoc build is here, too: https://qa-preprod-master.fxtest.jenkins.stage.mozaws.net/job/stubattribution.adhoc/211/console