### PR TITLE
Only apply triggers for the master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,8 @@ pipeline {
     lib('fxtest@1.10')
   }
   triggers {
-    pollSCM('H/30 * * * *')
-    cron('H * * * *')
+    pollSCM(env.BRANCH_NAME == 'master' ? 'H/30 * * * *' : '')
+    cron(env.BRANCH_NAME == 'master' ? 'H * * * *' : '')
   }
   options {
     ansiColor('xterm')


### PR DESCRIPTION
If this works Jenkins will only trigger a build according to the cron and poll schedule against the master branch. We should leave this pull request open for a while to confirm that it's working as expected.